### PR TITLE
Fix bash quoting in template executable

### DIFF
--- a/{{ cookiecutter.dir_name }}/{{ cookiecutter.formal_name }}
+++ b/{{ cookiecutter.dir_name }}/{{ cookiecutter.formal_name }}
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Set PYTHONPATH to point at app and app_packages directory
-export APPDIR=$(dirname $(readlink -f "$0"))
+export APPDIR=$(dirname "$(readlink -f \"$0\")")
 export PYTHONPATH=$APPDIR/app:$APPDIR/app_packages
 
 # Start the app


### PR DESCRIPTION
Signed-off-by: Lewis Gaul <lewis.gaul@gmail.com>

This PR addresses https://github.com/beeware/Python-Linux-template/issues/7 (and the dupe at https://github.com/beeware/briefcase/issues/274).

The problem was that the formal name is used for the bash executable, which means it can contain spaces. When running `APPDIR=$(dirname $(readlink -f "$0"))` in a file called "Hello World" this expands to `APPDIR=$(dirname /home/legaul/helloworld/linux/Hello World)` -> `APPDIR="/home/legaul/helloworld/linux ."`... And then we have a space floating around giving us a bad time :)

This PR adds the necessary quotes (have confirmed this fixes the issue). However, is it really desirable for the executable to use the formal name rather than the app name?